### PR TITLE
Fix: troca domínio bloqueado no ReiDosEmbeds

### DIFF
--- a/ReiDosEmbeds/src/main/kotlin/com/ReiDosEmbeds/ReiDosEmbeds.kt
+++ b/ReiDosEmbeds/src/main/kotlin/com/ReiDosEmbeds/ReiDosEmbeds.kt
@@ -192,7 +192,7 @@ class ReiDosEmbeds : MainAPI() {
                 playerUrl,
                 headers = mapOf(
                     "Referer" to playerUrl,
-                    "Origin" to "https://rde.buzz",
+                    "Origin" to "https://v2.rde.lat",
                     "User-Agent" to "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36"
                 )
             ).forEach(callback)


### PR DESCRIPTION
Atualiza o header `Origin` do provider ReiDosEmbeds de `https://rde.buzz` para `https://v2.rde.lat`.

O domínio `rde.buzz` foi bloqueado por algumas operadoras (aviso oficial do reidosembeds.com imagem abaixo). 
O header `Origin` estava hardcoded nesse domínio, o que pode derrubar os streams.
<img width="579" height="541" alt="Screenshot 2026-06-11 at 22 42 35" src="https://github.com/user-attachments/assets/fab70806-20ef-46f9-9e9b-258d83834ef8" />
